### PR TITLE
Decrease CI pipeline timeout

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   tox:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Decrease CI pipeline timeout, the default 6 hour timeout is too long:
- https://github.com/FAIRmat-NFDI/cookiecutter-nomad-pv-plugin/actions/runs/15904537427/job/44855730979


<img width="1438" alt="image" src="https://github.com/user-attachments/assets/1340c68e-bae3-40a1-b22a-0a9258849f4c" />
